### PR TITLE
Basic-Minimap-Functionality

### DIFF
--- a/Escargo/Assets/Scripts/PlayerScript.cs
+++ b/Escargo/Assets/Scripts/PlayerScript.cs
@@ -13,6 +13,7 @@ public class PlayerScript : MonoBehaviour {
     private int baseCullingMask;
     private Vector3 minimapPosition = new Vector3(24.5f,12.5f,-5.0f);
     private Camera c;
+	private float storedSpeed;
     /* Public Variables */
     public int slime = SLIME_MAX; //Slime remaining in slime bar. Initialized to be SLIME_MAX.
     public float moveSpeed = 2f; //Movement speed of snail.
@@ -27,6 +28,7 @@ public class PlayerScript : MonoBehaviour {
         // slider.maxValue = SLIME_MAX;
         c = gameObject.GetComponentInChildren<Camera>();
         baseCullingMask = c.cullingMask;
+		storedSpeed = moveSpeed;
     }
 
     void Update()
@@ -36,11 +38,14 @@ public class PlayerScript : MonoBehaviour {
             minimapActive = !minimapActive;
             if (!minimapActive)
             {
+				moveSpeed = storedSpeed;
                 c.transform.localPosition = new Vector3(0, 0, -1);
                 c.cullingMask = baseCullingMask;
             }
             else
             {
+				storedSpeed = moveSpeed;
+				moveSpeed = 0f;
                 c.cullingMask = (1 << LayerMask.NameToLayer("Background")) | (1 << LayerMask.NameToLayer("Minimap"));
             }
         }

--- a/Escargo/Assets/Scripts/PlayerScript.cs
+++ b/Escargo/Assets/Scripts/PlayerScript.cs
@@ -8,6 +8,11 @@ public class PlayerScript : MonoBehaviour {
     public const int SLIME_MAX = 100; //Maximum amount the slime bar can hold
     public const int SLIME_COST = 1; //Amount of slime reduced when using slime button.
 
+    /* Private Variables */
+    private bool minimapActive = false;
+    private int baseCullingMask;
+    private Vector3 minimapPosition = new Vector3(24.5f,12.5f,-5.0f);
+    private Camera c;
     /* Public Variables */
     public int slime = SLIME_MAX; //Slime remaining in slime bar. Initialized to be SLIME_MAX.
     public float moveSpeed = 2f; //Movement speed of snail.
@@ -15,9 +20,32 @@ public class PlayerScript : MonoBehaviour {
     public int playerID = 1;
     public int numSnailingsSaved = 0;
     public Text snaillingLabel;
+    public string minimapKey = "q";
 
     void Start()
     {
-       // slider.maxValue = SLIME_MAX;
+        // slider.maxValue = SLIME_MAX;
+        c = gameObject.GetComponentInChildren<Camera>();
+        baseCullingMask = c.cullingMask;
+    }
+
+    void Update()
+    {
+        if (Input.GetKeyUp(minimapKey))
+        {
+            minimapActive = !minimapActive;
+            if (!minimapActive)
+            {
+                c.transform.localPosition = new Vector3(0, 0, -1);
+                c.cullingMask = baseCullingMask;
+            }
+            else
+            {
+                c.cullingMask = (1 << LayerMask.NameToLayer("Background")) | (1 << LayerMask.NameToLayer("Minimap"));
+            }
+        }
+
+        if (minimapActive)
+            c.transform.position = minimapPosition;
     }
 }


### PR DESCRIPTION
Code added to change view from close up of snail to view of full map. To
make code work, the following changes need to be made to the scene:
- Two Layers need to be added: Background and Minimap. basicMap and
Escargo_Background_1 objects should be in the Background layer. Anything
that you wish to be displayed as a part of the minimap should be marked
as a part of the minimap layer (i.e. symbols showing slime and snail
positions rather than the players themselves).
- Minimap keys will have to be assigned for players other than player 1.
Default is "Q".