### PR TITLE
Fixed-Shelling-Slime-And-Possibly-Some-Crashes

### DIFF
--- a/Escargo/Assets/Scripts/GlobalScript.cs
+++ b/Escargo/Assets/Scripts/GlobalScript.cs
@@ -38,6 +38,10 @@ public class GlobalScript : MonoBehaviour {
 	public void changeDisplay(int playerID, int newSnaillingCount) {
 		for (int i = 0; i < NUM_PLAYERS; i++) {
 			if (players [i] != null) {
+				if (newSnaillingCount == 1) {
+					Color c = new Color (players [playerID - 1].playerColor.r, players [playerID - 1].playerColor.g, players [playerID - 1].playerColor.b, 255);
+					playersSnaillingDisplays [players [i].snaillingPanel] [playerID - 1].GetComponentInChildren<UnityEngine.UI.Slider> ().fillRect.GetComponent<UnityEngine.UI.Image> ().color = c;
+				}
 				playersSnaillingDisplays[players[i].snaillingPanel][playerID - 1].GetComponentInChildren<UnityEngine.UI.Text> ().text = newSnaillingCount.ToString ()
 				+ "/" + SnaillingScript.NUM_SNAILLINGS.ToString ();
 				playersSnaillingDisplays[players[i].snaillingPanel][playerID - 1].GetComponentInChildren<UnityEngine.UI.Slider> ().value = newSnaillingCount;
@@ -124,7 +128,9 @@ public class GlobalScript : MonoBehaviour {
 							prefab = Instantiate (snaillingDisplayPrefabs [BIGBERTHA]);
 						}
 						prefab.transform.SetParent (players [i].snaillingPanel.transform, false);
-						prefab.GetComponentInChildren<UnityEngine.UI.Slider> ().fillRect.GetComponent<UnityEngine.UI.Image> ().color = players [j].playerColor;
+						Color c = new Color (players [j].playerColor.r, players [j].playerColor.g, players [j].playerColor.b, 0);
+						prefab.GetComponentInChildren<UnityEngine.UI.Slider> ().fillRect.GetComponent<UnityEngine.UI.Image> ().color = c;
+						prefab.GetComponentInChildren<UnityEngine.UI.Text> ().text = "0/" + SnaillingScript.NUM_SNAILLINGS.ToString ();
 						prefabs [j] = prefab;
 					}
 				}

--- a/Escargo/Assets/Scripts/MoveScript.cs
+++ b/Escargo/Assets/Scripts/MoveScript.cs
@@ -26,7 +26,8 @@ public class MoveScript : MonoBehaviour
 	// 3 - Cornertrail
 	// 4 - Tritrail
 	// 5 - Quadtrail
-    private bool placeSlime = true;
+    private bool placeSlime = true; //Player's toggle for slime
+	private bool blockSlime = false; //System's ability to block laying of slime, regardless of player will.
 	private Animator anim;
 
 	void Start() {
@@ -72,7 +73,7 @@ public class MoveScript : MonoBehaviour
 
     void moveChar(Vector2 targetVelocity)
     {
-        if (placeSlime)
+        if (placeSlime && !blockSlime)
             setSlime();
 		float mSpeed = GetComponent<PlayerScript>().getMoveSpeed();
         GetComponent<Rigidbody2D>().velocity = targetVelocity * mSpeed;
@@ -240,7 +241,7 @@ public class MoveScript : MonoBehaviour
 		float pushback_force = 0.5f;
 		if (collision.gameObject.tag == "Player") {
 			anim.Play ("shelling");
-			Vector2 currentPos = gameObject.transform.localPosition;
+			blockSlime = true;
 			Vector2 direction = collision.contacts[0].point - new Vector2(transform.position.x, transform.position.y);
 			direction = -direction.normalized;
 			float savedSpeed = gameObject.GetComponent<PlayerScript> ().getMoveSpeed();
@@ -255,8 +256,14 @@ public class MoveScript : MonoBehaviour
 		if (gameObject.transform.localPosition.x < 0) {
 			gameObject.transform.localPosition = new Vector2(1.0f, gameObject.transform.localPosition.y);
 		}
-		if (gameObject.transform.localPosition.y > 24.5) {
-			gameObject.transform.localPosition = new Vector2(gameObject.transform.localPosition.x, 24.5f);
+		if (gameObject.transform.localPosition.x > SnaillingScript.WIDTH) {
+			gameObject.transform.localPosition = new Vector2(SnaillingScript.WIDTH - 1.0f, gameObject.transform.localPosition.y);
+		}
+		if (gameObject.transform.localPosition.y > SnaillingScript.HEIGHT) {
+			gameObject.transform.localPosition = new Vector2(gameObject.transform.localPosition.x, SnaillingScript.HEIGHT - 1.0f);
+		}
+		if (gameObject.transform.localPosition.y < 0) {
+			gameObject.transform.localPosition = new Vector2(gameObject.transform.localPosition.x, 1.0f);
 		}
 	}
 
@@ -264,7 +271,7 @@ public class MoveScript : MonoBehaviour
 	{
 		yield return new WaitForSeconds(1);
 		gameObject.GetComponent<PlayerScript> ().setMoveSpeed(storedSpeed);
-		//Remove Animation for Shell Collision here.
+		blockSlime = false;
 	}
 	public void setSlimeSprites(GameObject[] sprites) {
 		slimeSprites = sprites;

--- a/Escargo/Assets/Scripts/PowerUpScript.cs
+++ b/Escargo/Assets/Scripts/PowerUpScript.cs
@@ -30,10 +30,12 @@ public class PowerUpScript : MonoBehaviour
 	public PowerUpType powerUp;
 	private int respawnTime = 5;
 	// 5 seconds
-
-	void Start() {
+	private void generateRandomPowerUp() {
 		powerUp = (PowerUpType)UnityEngine.Random.Range (0, NUM_POWERUPS);
 		GetComponent<SpriteRenderer> ().sprite = images [(int)powerUp];
+	}
+	void Start() {
+		generateRandomPowerUp ();
 	}
 	void OnTriggerEnter2D (Collider2D collider)
 	{
@@ -109,6 +111,7 @@ public class PowerUpScript : MonoBehaviour
 	IEnumerator respawn ()
 	{
 		yield return new WaitForSeconds (respawnTime);
+		generateRandomPowerUp ();
 		setActive (true);
 	}
 }

--- a/Escargo/Assets/Scripts/SnaillingScript.cs
+++ b/Escargo/Assets/Scripts/SnaillingScript.cs
@@ -57,6 +57,7 @@ public class SnaillingScript : MonoBehaviour {
     private float snailStartX;
     private float snailStartY;
     private int deadend = 0;
+	private bool astarActive = false;
     Thread snailPathThread;
 
     void Start()
@@ -88,7 +89,6 @@ public class SnaillingScript : MonoBehaviour {
 				spawnTimer = 0f;
 				snaillings [currentSnail].transform.position = new Vector3 (snaillings [currentSnail].transform.position.x,
 					snaillings [currentSnail].transform.position.y, 0);
-                Debug.Log(snaillings[currentSnail].transform.position);
                 snaillings [currentSnail].tag = "P" + GetComponent<PlayerScript> ().playerID.ToString () + "Snailling";
 				currentSnail++;
 			}
@@ -101,8 +101,7 @@ public class SnaillingScript : MonoBehaviour {
 						int oX = (int)snaillings [i].transform.position.x;
 						int oY = (int)snaillings [i].transform.position.y;
 						bool simple = findSimplePath (i, oX, oY);
-                        Debug.Log(simple);
-						if (!simple && (deadend <= 1 || deadend > 5) && (snailPathThread == null || !snailPathThread.IsAlive)) {
+						if (!simple && (deadend <= 1 || deadend > 5) && (snailPathThread == null || !astarActive)) {
 							if (deadend > 5) {
 								deadend = 0;
 							}
@@ -112,11 +111,10 @@ public class SnaillingScript : MonoBehaviour {
 							}
 							KeyValuePair<int, int> n = closestNode [0];
 							if (!(oX == n.Key && oY == n.Value)) {
-                                //Debug.Log("pathfinding from " + oX +","+oY + " to " +n.Key + "," +n.Value);
                                 snailPathThread = new Thread (() => aStar (i, oX, oY, n.Key, n.Value));
+								astarActive = true;
 								snailPathThread.Start ();
-								while (!snailPathThread.IsAlive);
-								while (snailPathThread.IsAlive);
+								while (astarActive);
 							}
 						}
 
@@ -131,7 +129,6 @@ public class SnaillingScript : MonoBehaviour {
 							lock (snaillingsMove) {
 								newPos = snaillingsMove [i].Pop ();
 							}
-                            //Debug.Log("newPos: " + newPos.x + "," + newPos.y);
                             snaillings [i].transform.position = newPos; // actually make move
 							/*Lerp:
                             Vector3 origPos = snaillings [i].transform.position;
@@ -297,8 +294,8 @@ public class SnaillingScript : MonoBehaviour {
                 }
             }
         }
-        //Debug.Log("count at end fo astar: " +snaillingsMove[sID].Count);
-    }
+		astarActive = false;
+	}
 
     bool searchList(List<Node> l, Node n)
     {


### PR DESCRIPTION
Following things were changed:
1. When there are no snaillings to the end yet, the slider in teh
snailling panel will be transparent.
2. Power ups will now respawn randomly
3. When two snails collide, they will no longer output slime.
4. Possibility that the double while loop (!isActive and isActive)
caused Unity to crash in unknown situations. Changed this to a boolean
variable that does essentially the same thing. I have not noticed any
crashes after this change, but could use more testing.

Known bugs -
1. If you block a snaillings path while it is just spawning, Unity will
crash.
2. Two snails colliding will occasionally cause movement speed of a
snail to decrease.
3. Slime sprites occasionally display the incorrect sprite on top.